### PR TITLE
Correct references from 'Nugram' to 'Nutgram' across docs

### DIFF
--- a/docs/upgrading/from-1.x-to-2.x.md
+++ b/docs/upgrading/from-1.x-to-2.x.md
@@ -7,4 +7,4 @@ The update to the version 2.x contains only one breaking change.
 
 The Nutgram must be renamed:
 
-- `sergix44/nugram` to `nutgram/nutgram`
+- `sergix44/nutgram` to `nutgram/nutgram`

--- a/docs/usage/extend.md
+++ b/docs/usage/extend.md
@@ -9,7 +9,7 @@ it possible to add methods at runtime.
 You can add a new method using `macro`:
 
 ```php
-Nugram::macro('sendHelloMessage', function() {
+Nutgram::macro('sendHelloMessage', function() {
     return $this->sendMessage('Hello!');
 });
 
@@ -42,7 +42,7 @@ class CustomMethods {
     }
 }
 
-Nugram::mixin(new CustomMethods());
+Nutgram::mixin(new CustomMethods());
 
 $bot = new Nutgram('you telegram token here');
 $bot->sendHelloMessage();

--- a/versioned_docs/version-2.x/upgrading/from-1.x-to-2.x.md
+++ b/versioned_docs/version-2.x/upgrading/from-1.x-to-2.x.md
@@ -7,4 +7,4 @@ The update to the version 2.x contains only one breaking change.
 
 The Nutgram must be renamed:
 
-- `sergix44/nugram` to `nutgram/nutgram`
+- `sergix44/nutgram` to `nutgram/nutgram`

--- a/versioned_docs/version-2.x/usage/extend.md
+++ b/versioned_docs/version-2.x/usage/extend.md
@@ -9,7 +9,7 @@ it possible to add methods at runtime.
 You can add a new method using `macro`:
 
 ```php
-Nugram::macro('sendHelloMessage', function() {
+Nutgram::macro('sendHelloMessage', function() {
     return $this->sendMessage('Hello!');
 });
 
@@ -42,7 +42,7 @@ class CustomMethods {
     }
 }
 
-Nugram::mixin(new CustomMethods());
+Nutgram::mixin(new CustomMethods());
 
 $bot = new Nutgram('you telegram token here');
 $bot->sendHelloMessage();

--- a/versioned_docs/version-3.x/upgrading/from-1.x-to-2.x.md
+++ b/versioned_docs/version-3.x/upgrading/from-1.x-to-2.x.md
@@ -7,4 +7,4 @@ The update to the version 2.x contains only one breaking change.
 
 The Nutgram must be renamed:
 
-- `sergix44/nugram` to `nutgram/nutgram`
+- `sergix44/nutgram` to `nutgram/nutgram`

--- a/versioned_docs/version-3.x/usage/extend.md
+++ b/versioned_docs/version-3.x/usage/extend.md
@@ -9,7 +9,7 @@ it possible to add methods at runtime.
 You can add a new method using `macro`:
 
 ```php
-Nugram::macro('sendHelloMessage', function() {
+Nutgram::macro('sendHelloMessage', function() {
     return $this->sendMessage('Hello!');
 });
 
@@ -42,7 +42,7 @@ class CustomMethods {
     }
 }
 
-Nugram::mixin(new CustomMethods());
+Nutgram::mixin(new CustomMethods());
 
 $bot = new Nutgram('you telegram token here');
 $bot->sendHelloMessage();


### PR DESCRIPTION
This commit is addressing the error within documentation, where the class is erroneously referred to as 'Nugram'. All instances have been changed to the correct 'Nutgram'. This is reflected in the upgrading and usage docs across all the versions. This change will avoid confusing users who are following the documentation for implementation.