### PR TITLE
Sync to Nutgram latest changes

### DIFF
--- a/docs/usage/getting_updates.md
+++ b/docs/usage/getting_updates.md
@@ -88,6 +88,17 @@ If you are using Laravel, you can skip this section, but take a look at the corr
 
 :::
 
+### Set url programmatically
+
+You can set the webhook url programmatically, using the `setWebhook` method:
+
+```php
+use SergiX44\Nutgram\Nutgram;
+
+$bot = new Nutgram($_ENV['TOKEN']);
+$bot->setWebhook('your-webhook-url');
+```
+
 ## Customization
 
 You can create your own running mode, if these do not satisfy you, in fact, you will just create a class that extends

--- a/docs/usage/web_validation.md
+++ b/docs/usage/web_validation.md
@@ -30,6 +30,8 @@ try {
 With [Mini Apps](https://core.telegram.org/bots/webapps) developers can use JavaScript to create infinitely flexible interfaces 
 that can be launched right inside Telegram — and can completely replace any website.
 
+### Validating data received via the Mini App
+
 Nutgram provides the `validateWebAppData` method to validate the data received from the Mini App.<br/>
 If the data is valid, the method returns a 
 [`WebAppData`](https://github.com/nutgram/nutgram/blob/master/src/Telegram/Web/WebAppData.php) object,
@@ -45,6 +47,33 @@ otherwise it throws an `InvalidDataException`.
 
 try {
 	$webappData = $bot->validateWebAppData($initData);
+	//$webappData->user->id
+	//$webappData->toArray()['user']['id']
+} catch (InvalidDataException) {
+	echo 'Invalid data!';
+}
+```
+
+### Validating data for Third-Party Use
+
+Nutgram provides the `validateWebAppDataForThirdParty` method to validate the data received from the Mini App 
+for third-party use. This method can validate the data without requiring access to your bot's token.
+
+Simply provide them with your `bot_id` and the data from the `Telegram.WebApp.initData` field.<br/>
+If the data is valid, the method returns a
+[`WebAppData`](https://github.com/nutgram/nutgram/blob/master/src/Telegram/Web/WebAppData.php) object,
+otherwise it throws an `InvalidDataException`.
+
+```php
+// $initData MUST BE a query string value like this: 
+// user=%7B%22id%22%3A12345678%2C%22first_name%22%3A%22Mario%22%2C%22last_name%22%3A%22Super%22%2C%22username%22%3A%22SuperMario%22%2C%22language_code%22%3A%22en%22%2C%22is_premium%22%3Atrue%2C%22allows_write_to_pm%22%3Atrue%7D&chat_instance=-123456789&chat_type=private&start_param=foo&auth_date=1693264973&hash=1a2b3c4d5e6f
+
+// how to get $initData from frontend (example): 
+// $initData = $_GET['initData'] or $_POST['initData'];
+// initData is an example key name provided by frontend
+
+try {
+	$webappData = Nutgram::validateWebAppDataForThirdParty(123456789, $initData);
 	//$webappData->user->id
 	//$webappData->toArray()['user']['id']
 } catch (InvalidDataException) {


### PR DESCRIPTION
This pull request includes several updates to the documentation to enhance the clarity and comprehensiveness of usage instructions for Nutgram. The most important changes include adding new sections on setting the webhook URL programmatically, updating examples for sending requests, and providing detailed instructions for uploading and downloading files with progress tracking.

### Documentation Enhancements:

* [`docs/usage/getting_updates.md`](diffhunk://#diff-4bd31d3210ea3960360733ac6348e99de84c3136f052a207bf86c4a9050932b6R91-R101): Added a section on how to set the webhook URL programmatically using the `setWebhook` method.
* [`docs/usage/web_validation.md`](diffhunk://#diff-19cf43522ebb6cd1be344757ea5a9fcc19a25ed3bd4d9cba51c61f04804c87d1R56-R82): Introduced a new section on validating data for third-party use with the `validateWebAppDataForThirdParty` method.

### Sending Requests Examples:

* [`docs/usage/sending_requests.md`](diffhunk://#diff-b10cac315f5a07b98e674978f822638dc313231fc424c1e3f68602d87a706a87L23-L30): Updated examples for sending messages, photos, and videos to use the correct `chat_id` and added examples for sending media via URL and `InputFile`. [[1]](diffhunk://#diff-b10cac315f5a07b98e674978f822638dc313231fc424c1e3f68602d87a706a87L23-L30) [[2]](diffhunk://#diff-b10cac315f5a07b98e674978f822638dc313231fc424c1e3f68602d87a706a87L42-R40) [[3]](diffhunk://#diff-b10cac315f5a07b98e674978f822638dc313231fc424c1e3f68602d87a706a87L51-R210)

### File Upload and Download:

* [`docs/usage/sending_requests.md`](diffhunk://#diff-b10cac315f5a07b98e674978f822638dc313231fc424c1e3f68602d87a706a87L51-R210): Added detailed instructions on uploading files with progress tracking using the `withProgress` method.
* [`docs/usage/sending_requests.md`](diffhunk://#diff-b10cac315f5a07b98e674978f822638dc313231fc424c1e3f68602d87a706a87L51-R210): Added detailed instructions on downloading files with progress tracking using the `withProgress` method.

### Formatting Options:

* [`docs/usage/sending_requests.md`](diffhunk://#diff-b10cac315f5a07b98e674978f822638dc313231fc424c1e3f68602d87a706a87L117-R229): Updated the section on formatting text messages to use the `parse_mode` parameter and provided examples using the ParseMode enum.